### PR TITLE
Fixing integration with Prometheus

### DIFF
--- a/src/main/kotlin/promeureka/model/PrometheusItem.kt
+++ b/src/main/kotlin/promeureka/model/PrometheusItem.kt
@@ -1,3 +1,3 @@
 package promeureka.model
 
-data class PrometheusItem(val label: PrometheusLabel, val targets: List<String>)
+data class PrometheusItem(val labels: PrometheusLabel, val targets: List<String>)


### PR DESCRIPTION
As described [here][prometheus-doc], the json file that Prometheus will read should use this format:

```json
[ { "targets": [ ], "labels": { } } ]
```

But instead the current format is this:

```json
[ { "targets": [ ], "label": { } } ]
```

[prometheus-doc]: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#%3Cfile_sd_config%3E